### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Inherit from chriswessels/meteor-tupperware image
+FROM quay.io/chriswessels/meteor-tupperware
+
+# (optional) Bake runtime options into your image
+# ENV MONGO_URL="mongodb://url" MONGO_OPLOG_URL="mongodb://oplog_url" ROOT_URL="http://yourapp.com"
+
+# If using Kubernetes, construct the MONGO_URL based on service variables
+# ENTRYPOINT MONGO_URL=mongodb://$MONGO_SERVICE_HOST:$MONGO_SERVICE_PORT/$DATABASE_NAME MONGO_OPLOG_URL=mongodb://$MONGO_SERVICE_HOST:$MONGO_SERVICE_PORT/local sh /tupperware/scripts/start_app.sh


### PR DESCRIPTION
Added a Dockerfile to use `meteor-tupperware` to turn DrMongo into a Docker image with `docker build`.

It's automatically optimised for production usage, and all you need to do is pass the same options you would when starting the application in production (provide MONGO_URL, ROOT_URL, etc).

More docs here: https://github.com/chriswessels/meteor-tupperware
